### PR TITLE
Update title in array decorator template

### DIFF
--- a/src/directives/decorators/bootstrap/array.html
+++ b/src/directives/decorators/bootstrap/array.html
@@ -1,6 +1,6 @@
 <div sf-array="form" class="schema-form-array {{form.htmlClass}}"
      ng-model="$$value$$" ng-model-options="form.ngModelOptions">
-  <h3 ng-show="form.title && form.notitle !== true">{{ form.title }}</h3>
+  <label class="control-label" ng-show="showTitle()">{{ form.title }}</label>
   <ol class="list-group" ng-model="modelArray" ui-sortable>
     <li class="list-group-item {{form.fieldHtmlClass}}"
         ng-repeat="item in modelArray track by $index">


### PR DESCRIPTION
This commit aims to make the array decorator template more idiomatic by replacing the `<h3>` element in the title, with the `<label>` element common to the other decorate template titles.

In addition this commit also replaces the inline `ng-show` logic with the `showTitle()` method, which looks to be equivalent.

This commit doesn't seem to impact any tests. I have ran them all and they pass.
